### PR TITLE
 one class: red or green, never both in the same time and never empty

### DIFF
--- a/0x15-javascript-web_jquery/4-script.js
+++ b/0x15-javascript-web_jquery/4-script.js
@@ -1,0 +1,3 @@
+$('DIV#toggle_header').click(function () {
+  $('HEADER').toggleClass('green red');
+});

--- a/0x15-javascript-web_jquery/tests/4-main.html
+++ b/0x15-javascript-web_jquery/tests/4-main.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Holberton School</title>
+    <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+    <style>
+      .red {
+        color: #FF0000;
+      }
+      .green {
+        color: #00FF00;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="green"> 
+      First HTML page
+    </header>
+    <div id="toggle_header">Toggle header</div>
+    <footer>
+      Holberton School - 2017
+    </footer>
+    <script type="text/javascript" src="4-script.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
The <header> element must always have one class: red or green, never both in the same time and never empty.
If the current class is red, when the user click on DIV#toggle_header, the class must be updated to green ; and the reverse.
You can’t use document.querySelector to select the HTML tag
You must use the JQuery API