### PR TITLE
 script that updates the text color of the <header> element to red

### DIFF
--- a/0x15-javascript-web_jquery/100-script.js
+++ b/0x15-javascript-web_jquery/100-script.js
@@ -1,0 +1,3 @@
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelector('HEADER').style.color = '#FF0000';
+});

--- a/0x15-javascript-web_jquery/tests/100-main.html
+++ b/0x15-javascript-web_jquery/tests/100-main.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Holberton School</title>
+    <script type="text/javascript" src="100-script.js"></script>
+  </head>
+  <body>
+    <header> 
+      First HTML page
+    </header>
+    <footer>
+      Holberton School - 2017
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
script that updates the text color of the <header> element to red (#FF0000):

used document.querySelector to select the HTML tag
can’t use the jQuery API
